### PR TITLE
Fix sandbox stability tests and tier 3 fallback

### DIFF
--- a/apps/runtime/sandbox_executor.py
+++ b/apps/runtime/sandbox_executor.py
@@ -53,26 +53,38 @@ def execute_code_safely(code: str, timeout: int = 60) -> dict:
     try:
         # Readiness check before actual execution
         readiness = _check_docker_readiness()
-        if not readiness["ready"]:
-            print(f"[sandbox] Tier 2 (Docker) readiness check failed: {readiness['reason']}")
-            # Fall through to Tier 3
-        else:
+        if readiness["ready"]:
             from utils.docker_executor import run_in_docker
             res = run_in_docker(code, timeout=timeout)
             return {
                 "tier": 2,
                 **res
             }
+        else:
+            print(f"[sandbox] Tier 2 (Docker) readiness check failed: {readiness['reason']}")
     except Exception as e:
         logger.error(f"[sandbox] Tier 2 (Docker) failed: {e}")
 
-    # Tier 3: Skip
+    # Tier 3: Local venv fallback
+    try:
+        ensure_venv(VENV_DIR)
+        python_path = get_venv_python(VENV_DIR)
+        res = run_in_venv(python_path, code, timeout=timeout)
+        return {
+            "tier": 3,
+            **res,
+            "skipped": False,
+        }
+    except Exception as e:
+        logger.warning(f"[sandbox] Tier 3 (local venv) failed: {e}")
+
+    # Tier 4: Skip
     return {
-        "tier": 3,
-        "success": False,  # Don't allow false positive success
+        "tier": 3,  # Keep tier 3 as the final state for legacy compatibility
+        "success": False,
         "skipped": True,
         "verification_skipped": True,
-        "reason": "Both e2b and local venv failed or were unavailable"
+        "reason": "e2b, Docker, and local venv failed or were unavailable"
     }
 
 def execute_artifact_safely(artifact_path: Path, timeout: int = 60) -> dict:

--- a/apps/runtime/sandbox_executor.py
+++ b/apps/runtime/sandbox_executor.py
@@ -23,12 +23,17 @@ def _check_docker_readiness() -> dict:
 
 
 def execute_code_safely(code: str, timeout: int = 60) -> dict:
-    """Execute Python code with 3-tier fallback.
+    """Execute Python code with fallback tiers.
     
     Tiers:
-        1. e2b Cloud
-        2. Local venv
-        3. Skip (Warn)
+        1. e2b Cloud Sandbox: Remote isolated environment (Primary).
+        2. Docker Container: Local isolated container (Secondary).
+        3. Local venv fallback: Local execution using utils.safe_subprocess (Tertiary).
+           Note: Local venv provides lower isolation than Docker/e2b and is used as 
+           a final execution attempt with strict timeout enforcement.
+
+    Final Fallback:
+        - Return skipped=True when all execution tiers are unavailable or fail.
     """
     # Tier 1: e2b
     api_key = os.environ.get("E2B_API_KEY")

--- a/docs/known_issues_sandbox_tests.md
+++ b/docs/known_issues_sandbox_tests.md
@@ -1,6 +1,8 @@
-# Known Issues: Sandbox Tests [RESOLVED]
+# Resolved: Sandbox Stability Test Failures
 
 The previously identified failures in the sandbox execution tier tests have been resolved in the `fix/sandbox-stability-tests` branch.
+
+**Resolves #2**
 
 ## Status: RESOLVED
 
@@ -15,6 +17,7 @@ The previously identified failures in the sandbox execution tier tests have been
 
 ### 2. Tier 3 Implementation
 - Restored the missing Tier 3 "Local venv" fallback in `apps/runtime/sandbox_executor.py` using `utils.safe_subprocess`.
+- Added a safety note regarding lower isolation in local venv compared to Docker/e2b.
 - Split `test_tier_3_fallback` into two targeted tests:
     - `test_tier_3_local_venv_execution`: Verifies successful fallback to local venv when e2b and Docker fail.
     - `test_all_tiers_fail_skip`: Verifies the final "Skip" state when all execution tiers (including local venv) fail.

--- a/docs/known_issues_sandbox_tests.md
+++ b/docs/known_issues_sandbox_tests.md
@@ -1,30 +1,27 @@
-# Known Issues: Sandbox Tests
+# Known Issues: Sandbox Tests [RESOLVED]
 
-This document tracks existing failures in the sandbox execution tier tests that are outside the scope of the P0 HITL Promotion fix.
+The previously identified failures in the sandbox execution tier tests have been resolved in the `fix/sandbox-stability-tests` branch.
 
-## Affected Tests
+## Status: RESOLVED
 
-- `tests/test_sandbox.py::test_tier_2_local_execution`
-- `tests/test_sandbox.py::test_tier_3_fallback`
+- `tests/test_sandbox.py::test_tier_2_local_execution` -> **RESOLVED** (Updated to `test_tier_2_docker_execution`)
+- `tests/test_sandbox.py::test_tier_3_fallback` -> **RESOLVED** (Implemented Tier 3 Local venv fallback and updated test verification)
 
-## Failure Details
+## Fix Details
 
-### 1. `test_tier_2_local_execution`
-- **Error**: `AttributeError: <module 'apps.runtime.sandbox_executor'> does not have the attribute '_check_tier2_readiness'`
-- **Cause**: The test attempts to mock a function (`_check_tier2_readiness`) that either does not exist in the current version of `sandbox_executor.py` or was renamed/refactored.
-- **Impact**: Tier 2 (Docker) readiness detection logic is not being correctly validated in this test.
+### 1. Tier 2 Alignment
+- Renamed the test to `test_tier_2_docker_execution` to match the implementation that uses Docker for Tier 2.
+- Updated mocks to target `_check_docker_readiness` and `run_in_docker`.
 
-### 2. `test_tier_3_fallback`
-- **Error**: `AssertionError: assert 2 == 3`
-- **Cause**: The test expects a fallback to Tier 3 (Local), but the executor stops at Tier 2 or returns a different tier level than expected.
-- **Impact**: The 3-tier fallback logic needs synchronization between the implementation and the test expectations.
+### 2. Tier 3 Implementation
+- Restored the missing Tier 3 "Local venv" fallback in `apps/runtime/sandbox_executor.py` using `utils.safe_subprocess`.
+- Split `test_tier_3_fallback` into two targeted tests:
+    - `test_tier_3_local_venv_execution`: Verifies successful fallback to local venv when e2b and Docker fail.
+    - `test_all_tiers_fail_skip`: Verifies the final "Skip" state when all execution tiers (including local venv) fail.
 
-## History
+## Verification
 
-These failures were first identified in the baseline prior to the HITL Promotion hardening (Commit `c67b905`). They do not affect the integrity of the job promotion state machine or the daemon's ability to dispatch jobs.
-
-## Resolution Plan
-
-1.  **Audit `apps/runtime/sandbox_executor.py`**: Confirm the current implementation of readiness checks.
-2.  **Update `tests/test_sandbox.py`**: Align test mocks and assertions with the actual 3-tier logic.
-3.  **Target**: Resolve in a follow-up PR focused on "Sandbox Stability".
+The entire test suite (`pytest tests/`) is now 100% green.
+- `tests/test_sandbox.py`: 4/4 PASSED
+- `tests/test_promotion_state_machine.py`: 28/28 PASSED
+- Total: 79 PASSED

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -4,27 +4,6 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from apps.runtime.sandbox_executor import execute_code_safely
 
-def test_tier_2_local_execution():
-    """Verify that local execution works when e2b is disabled."""
-    with patch.dict("os.environ", {"E2B_API_KEY": ""}):
-        with patch("apps.runtime.sandbox_executor.ensure_venv") as mock_ensure:
-            with patch("apps.runtime.sandbox_executor._check_tier2_readiness") as mock_ready:
-                mock_ready.return_value = {"ready": True}
-                with patch("apps.runtime.sandbox_executor.run_in_venv") as mock_run:
-                    mock_run.return_value = {
-                        "stdout": "hello from sandbox",
-                        "stderr": "",
-                        "exit_code": 0,
-                        "success": True
-                    }
-                    code = "print('hello from sandbox')"
-                    result = execute_code_safely(code)
-                    # Tier 2 should be used if e2b is disabled
-                    assert result["tier"] == 2
-                    assert "hello from sandbox" in result["stdout"]
-                    assert result["success"] is True
-                    mock_ensure.assert_called_once()
-
 def test_tier_1_e2b_mocked():
     """Verify that e2b is prioritized when API key is present."""
     with patch.dict("os.environ", {"E2B_API_KEY": "fake_key"}):
@@ -41,12 +20,63 @@ def test_tier_1_e2b_mocked():
             assert result["tier"] == 1
             assert "e2b output" in result["stdout"]
 
-def test_tier_3_fallback():
-    """Verify fallback to tier 3 when both e2b and local fail."""
+def test_tier_2_docker_execution():
+    """Verify that Docker execution works when e2b is disabled."""
     with patch.dict("os.environ", {"E2B_API_KEY": ""}):
-        with patch("apps.runtime.sandbox_executor.ensure_venv", side_effect=Exception("Venv failed")):
-            code = "print('hello')"
-            result = execute_code_safely(code)
-            assert result["tier"] == 3
-            assert result["skipped"] is True
-            assert result["success"] is False
+        with patch("apps.runtime.sandbox_executor._check_docker_readiness") as mock_ready:
+            mock_ready.return_value = {"ready": True}
+            with patch("utils.docker_executor.run_in_docker") as mock_run:
+                mock_run.return_value = {
+                    "stdout": "hello from docker",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "success": True
+                }
+                code = "print('hello from docker')"
+                result = execute_code_safely(code)
+                assert result["tier"] == 2
+                assert "hello from docker" in result["stdout"]
+                assert result["success"] is True
+                mock_run.assert_called_once()
+
+def test_tier_3_local_venv_execution():
+    """Verify that local venv fallback works when Docker is unavailable."""
+    with patch.dict("os.environ", {"E2B_API_KEY": ""}):
+        # Mock Docker as unavailable
+        with patch("apps.runtime.sandbox_executor._check_docker_readiness") as mock_ready:
+            mock_ready.return_value = {"ready": False, "reason": "No docker"}
+            
+            with patch("apps.runtime.sandbox_executor.ensure_venv") as mock_ensure:
+                with patch("apps.runtime.sandbox_executor.run_in_venv") as mock_run:
+                    mock_run.return_value = {
+                        "stdout": "hello from venv",
+                        "stderr": "",
+                        "exit_code": 0,
+                        "success": True
+                    }
+                    code = "print('hello from venv')"
+                    result = execute_code_safely(code)
+                    
+                    assert result["tier"] == 3
+                    assert result["success"] is True
+                    assert result["skipped"] is False
+                    assert "hello from venv" in result["stdout"]
+                    mock_ensure.assert_called_once()
+                    mock_run.assert_called_once()
+
+def test_all_tiers_fail_skip():
+    """Verify fallback to skip state when all tiers fail."""
+    with patch.dict("os.environ", {"E2B_API_KEY": ""}):
+        # Mock Docker as unavailable
+        with patch("apps.runtime.sandbox_executor._check_docker_readiness") as mock_ready:
+            mock_ready.return_value = {"ready": False, "reason": "No docker"}
+            
+            # Mock local venv as failing
+            with patch("apps.runtime.sandbox_executor.ensure_venv", side_effect=Exception("Venv setup failed")):
+                code = "print('hello')"
+                result = execute_code_safely(code)
+                
+                assert result["tier"] == 3
+                assert result["skipped"] is True
+                assert result["success"] is False
+                assert result["verification_skipped"] is True


### PR DESCRIPTION
## Summary

Fixes sandbox stability failures tracked in #2.

- Restores Tier 3 Local venv fallback in `apps/runtime/sandbox_executor.py`
- Aligns Tier 2 tests with Docker execution
- Adds/updates sandbox regression coverage for:
  - Tier 1 e2b
  - Tier 2 Docker
  - Tier 3 Local venv
  - final skip fallback
- Documents that Local venv has lower isolation than Docker/e2b and is executed through `utils.safe_subprocess`
- Marks sandbox known failures as resolved

## Test Results

- `pytest tests/test_sandbox.py -v --tb=short`: 4/4 PASSED
- `pytest tests/test_promotion_state_machine.py -q`: PASSED
- `pytest tests/ -q --tb=short`: 79 PASSED

## Security

- Secret grep completed
- No real secrets found; only placeholders/pattern definitions if any

## Closes

Resolves #2