### PR TITLE
Fix runtime concurrency hardening

### DIFF
--- a/apps/llm_router/router.py
+++ b/apps/llm_router/router.py
@@ -30,6 +30,13 @@ except ImportError:
 from utils.atomic_io import atomic_append
 
 
+import threading
+
+# Singleton management
+_router_instance = None
+_router_lock = threading.RLock()
+
+
 class ProviderExhaustedError(Exception):
     """Raised when provider-switch budget is exceeded."""
     pass
@@ -46,12 +53,27 @@ class UnifiedRouter:
 
     MAX_SWITCHES = 2
 
+    def __new__(cls, *args, **kwargs):
+        global _router_instance
+        if _router_instance is None:
+            with _router_lock:
+                if _router_instance is None:
+                    _router_instance = super().__new__(cls)
+        return _router_instance
+
     def __init__(self, log_path: str = "work/model_calls.jsonl") -> None:
-        self.nvidia_api_key = os.environ.get("NVIDIA_API_KEY", "")
-        self.ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
-        self.log_path = Path(log_path)
-        self.log_path.parent.mkdir(parents=True, exist_ok=True)
-        self._switch_count = 0
+        with _router_lock:
+            if getattr(self, "_initialized", False):
+                return
+
+            self.nvidia_api_key = os.environ.get("NVIDIA_API_KEY", "")
+            self.ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+            self.log_path = Path(log_path)
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            self._switch_count = 0
+            self._state_lock = threading.RLock()
+
+            self._initialized = True
 
     def get_llm(self, context: str):
         """Get appropriate LLM for the given context.
@@ -101,13 +123,15 @@ class UnifiedRouter:
         Raises:
             ProviderExhaustedError: if budget exceeded
         """
-        if self._switch_count >= self.MAX_SWITCHES:
-            raise ProviderExhaustedError(
-                f"Provider-switch budget exceeded ({self.MAX_SWITCHES} max)"
-            )
-        self._switch_count += 1
-        self._log_call("system", "provider_switch", f"switch_{self._switch_count}")
-        return "ollama" if self._switch_count % 2 == 1 else "nvidia_nim"
+        with self._state_lock:
+            if self._switch_count >= self.MAX_SWITCHES:
+                raise ProviderExhaustedError(
+                    f"Provider-switch budget exceeded ({self.MAX_SWITCHES} max)"
+                )
+            self._switch_count += 1
+            count = self._switch_count
+            self._log_call("system", "provider_switch", f"switch_{count}")
+            return "ollama" if count % 2 == 1 else "nvidia_nim"
 
     def _log_call(self, provider: str, model: str, context: str) -> None:
         entry = {
@@ -117,3 +141,8 @@ class UnifiedRouter:
             "context": context,
         }
         atomic_append(self.log_path, json.dumps(entry, ensure_ascii=False))
+
+
+def get_router() -> UnifiedRouter:
+    """Helper to get the singleton UnifiedRouter instance."""
+    return UnifiedRouter()

--- a/domains/feedback_memory.py
+++ b/domains/feedback_memory.py
@@ -28,12 +28,13 @@ class FeedbackMemory:
         self.model = SentenceTransformer('paraphrase-multilingual-MiniLM-L12-v2')
         self.dimension = 384
         
-        # 排他制御用ロック
-        self.lock = threading.Lock()
+        # 排他制御用ロック (再入可能ロックを使用)
+        self.lock = threading.RLock()
         
-        # インデックスとメタデータの初期化
-        self.index = self._load_index()
-        self.metadata = self._load_metadata()
+        with self.lock:
+            # インデックスとメタデータの初期化
+            self.index = self._load_index()
+            self.metadata = self._load_metadata()
 
     def _load_index(self):
         if self.index_path.exists():
@@ -58,12 +59,13 @@ class FeedbackMemory:
         if not task_description or not feedback:
             return
 
-        # 1. 埋め込み生成と L2 正規化 (コサイン類似度用)
-        embedding = self.model.encode([task_description])[0].astype('float32')
-        embedding_arr = np.array([embedding])
-        faiss.normalize_L2(embedding_arr)
-        
         with self.lock:
+            # 1. 埋め込み生成と L2 正規化 (コサイン類似度用)
+            # ロック内で実行し、モデルへのアクセスを直列化
+            embedding = self.model.encode([task_description])[0].astype('float32')
+            embedding_arr = np.array([embedding])
+            faiss.normalize_L2(embedding_arr)
+            
             # 2. FAISS インデックスに追加
             self.index.add(embedding_arr)
             
@@ -75,48 +77,70 @@ class FeedbackMemory:
                 "timestamp": datetime.utcnow().isoformat() + "Z"
             })
             
-            # 4. 物理ファイルへの永続化
+            # 4. 物理ファイルへの永続化 (Atomic Save)
             self._save()
             logger.info(f"Learned new lesson from job {job_id}", extra={"job_id": job_id})
 
     def search_lessons(self, current_task: str, top_k=3, threshold=0.5) -> list[str]:
         """現在のタスクに類似した過去の教訓を検索 (閾値以上のものを返す)"""
-        if not current_task or self.index.ntotal == 0:
-            return []
+        with self.lock:
+            if not current_task or self.index.ntotal == 0:
+                return []
 
-        # 1. クエリの埋め込み生成と正規化
-        query_vector = self.model.encode([current_task])[0].astype('float32')
-        query_arr = np.array([query_vector])
-        faiss.normalize_L2(query_arr)
-        
-        # 2. 内積検索 (正規化済みなのでコサイン類似度と同等)
-        distances, indices = self.index.search(query_arr, top_k)
-
-        results = []
-        for score, idx in zip(distances[0], indices[0]):
-            if idx == -1: continue
+            # 1. クエリの埋め込み生成と正規化
+            query_vector = self.model.encode([current_task])[0].astype('float32')
+            query_arr = np.array([query_vector])
+            faiss.normalize_L2(query_arr)
             
-            # コサイン類似度が閾値以上なら採用
-            if score > threshold: 
-                meta = self.metadata[idx]
-                results.append(
-                    f"Past Task: {meta['task']}\n"
-                    f"   -> Lesson: {meta['feedback']} (Similarity: {score:.2f})"
-                )
-        
-        return results
+            # 2. 内積検索 (正規化済みなのでコサイン類似度と同等)
+            distances, indices = self.index.search(query_arr, top_k)
+
+            results = []
+            for score, idx in zip(distances[0], indices[0]):
+                if idx == -1: continue
+                
+                # コサイン類似度が閾値以上なら採用
+                if score > threshold: 
+                    meta = self.metadata[idx]
+                    results.append(
+                        f"Past Task: {meta['task']}\n"
+                        f"   -> Lesson: {meta['feedback']} (Similarity: {score:.2f})"
+                    )
+            
+            return results
 
     def _save(self):
-        """インデックスとメタデータを物理ファイルに保存"""
-        faiss.write_index(self.index, str(self.index_path))
-        with open(self.meta_path, "w", encoding="utf-8") as f:
-            json.dump(self.metadata, f, indent=2, ensure_ascii=False)
+        """インデックスとメタデータを物理ファイルにアトミックに保存"""
+        # 1. インデックスのアトミック保存
+        tmp_index = self.index_path.with_suffix(".index.tmp")
+        try:
+            faiss.write_index(self.index, str(tmp_index))
+            os.replace(tmp_index, self.index_path)
+        except Exception as e:
+            logger.error(f"Failed atomic save for FAISS index: {e}")
+            if tmp_index.exists(): tmp_index.unlink()
+
+        # 2. メタデータのアトミック保存
+        tmp_meta = self.meta_path.with_suffix(".json.tmp")
+        try:
+            with open(tmp_meta, "w", encoding="utf-8") as f:
+                json.dump(self.metadata, f, indent=2, ensure_ascii=False)
+            os.replace(tmp_meta, self.meta_path)
+        except Exception as e:
+            logger.error(f"Failed atomic save for metadata: {e}")
+            if tmp_meta.exists(): tmp_meta.unlink()
+
+        # 注意: このメソッドは個別のファイル破損を防ぎますが、
+        # インデックスとメタデータの間のマルチファイル・トランザクションは提供しません。
 
 # Singleton Instance Management
 _memory_instance = None
+_memory_lock = threading.RLock()
 
 def get_feedback_memory() -> FeedbackMemory:
     global _memory_instance
     if _memory_instance is None:
-        _memory_instance = FeedbackMemory()
+        with _memory_lock:
+            if _memory_instance is None:
+                _memory_instance = FeedbackMemory()
     return _memory_instance

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,156 @@
+import threading
+import os
+import json
+import pytest
+import numpy as np
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch, mock_open
+
+from domains.feedback_memory import get_feedback_memory, FeedbackMemory
+from apps.llm_router.router import UnifiedRouter, get_router, ProviderExhaustedError
+import domains.feedback_memory
+import apps.llm_router.router
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset singleton instances before each test."""
+    domains.feedback_memory._memory_instance = None
+    apps.llm_router.router._router_instance = None
+    yield
+
+@patch("domains.feedback_memory.SentenceTransformer")
+@patch("domains.feedback_memory.faiss")
+def test_get_feedback_memory_concurrent_singleton(mock_faiss, mock_st):
+    """Verify thread-safe singleton instantiation for FeedbackMemory."""
+    mock_model = MagicMock()
+    mock_st.return_value = mock_model
+    
+    mock_index = MagicMock()
+    mock_faiss.IndexFlatIP.return_value = mock_index
+    
+    def get_instance():
+        return get_feedback_memory()
+    
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        instances = list(executor.map(lambda _: get_instance(), range(10)))
+    
+    assert all(inst is instances[0] for inst in instances)
+    assert mock_st.call_count == 1
+
+@patch("domains.feedback_memory.SentenceTransformer")
+@patch("domains.feedback_memory.faiss")
+@patch("os.replace")
+def test_feedback_memory_atomic_save_uses_temp_then_replace(mock_replace, mock_faiss, mock_st, tmp_path):
+    """Verify _save uses temporary files and os.replace for atomicity."""
+    memory = FeedbackMemory(storage_dir=tmp_path)
+    memory._save()
+    
+    assert mock_faiss.write_index.called
+    args, _ = mock_faiss.write_index.call_args
+    assert str(args[1]).endswith(".index.tmp")
+    mock_replace.assert_any_call(Path(args[1]), memory.index_path)
+    
+    found_meta_replace = False
+    for call in mock_replace.call_args_list:
+        if str(call[0][1]).endswith("lessons_meta.json"):
+            found_meta_replace = True
+            assert str(call[0][0]).endswith(".json.tmp")
+    assert found_meta_replace
+
+@patch("domains.feedback_memory.SentenceTransformer")
+@patch("domains.feedback_memory.faiss")
+def test_feedback_memory_concurrent_add_and_search_does_not_crash(mock_faiss, mock_st, tmp_path):
+    """Verify concurrent add and search operations do not cause race conditions or crashes."""
+    mock_model = MagicMock()
+    mock_st.return_value = mock_model
+    # Return a 384-dim vector for embeddings
+    mock_model.encode.return_value = np.zeros((1, 384), dtype='float32')
+    
+    mock_index = MagicMock()
+    mock_faiss.IndexFlatIP.return_value = mock_index
+    mock_index.ntotal = 5
+    # Mock search result: distances, indices
+    mock_index.search.return_value = (np.array([[0.8]]), np.array([[0]]))
+    
+    memory = FeedbackMemory(storage_dir=tmp_path)
+    # Pre-populate metadata to avoid index errors in search
+    memory.metadata = [{"task": "t", "feedback": "f", "job_id": "j"}] * 10
+    
+    def worker_add():
+        for i in range(20):
+            memory.add_lesson(f"task {i}", "feedback", f"job-{i}")
+            
+    def worker_search():
+        for i in range(20):
+            memory.search_lessons(f"query {i}")
+            
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = []
+        for _ in range(4):
+            futures.append(executor.submit(worker_add))
+            futures.append(executor.submit(worker_search))
+        
+        for f in futures:
+            f.result()
+            
+    assert len(memory.metadata) >= 80
+
+def test_unified_router_singleton():
+    """Verify UnifiedRouter construction returns a singleton instance."""
+    with patch.dict(os.environ, {"NVIDIA_API_KEY": "mock"}):
+        with patch("apps.llm_router.router.LLM"):
+            def get_instance():
+                return UnifiedRouter()
+            
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                instances = list(executor.map(lambda _: get_instance(), range(10)))
+            
+            assert all(inst is instances[0] for inst in instances)
+            assert get_router() is instances[0]
+
+def test_unified_router_init_is_thread_safe():
+    """Verify concurrent UnifiedRouter() calls do not expose partially initialized instances."""
+    with patch.dict(os.environ, {"NVIDIA_API_KEY": "mock"}):
+        with patch("apps.llm_router.router.LLM"):
+            def get_instance():
+                inst = UnifiedRouter()
+                # If race occurs, fields might be missing or _initialized might be True prematurely
+                assert hasattr(inst, "nvidia_api_key")
+                assert hasattr(inst, "_state_lock")
+                assert inst._initialized is True
+                return inst
+
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                instances = list(executor.map(lambda _: get_instance(), range(10)))
+            
+            assert all(inst is instances[0] for inst in instances)
+
+def test_unified_router_switch_provider_budget_thread_safe():
+    """Verify concurrent switch_provider() calls respect budget and are thread-safe."""
+    with patch.dict(os.environ, {"NVIDIA_API_KEY": "mock"}):
+        with patch("apps.llm_router.router.LLM"):
+            router = UnifiedRouter()
+            router._switch_count = 0
+            router.MAX_SWITCHES = 50
+            
+            # Mock _log_call to avoid file I/O
+            router._log_call = MagicMock()
+            
+            def worker_switch():
+                successes = 0
+                for _ in range(20):
+                    try:
+                        router.switch_provider()
+                        successes += 1
+                    except ProviderExhaustedError:
+                        pass
+                return successes
+
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                results = list(executor.map(lambda _: worker_switch(), range(10)))
+            
+            total_successes = sum(results)
+            assert total_successes == 50
+            assert router._switch_count == 50
+            assert router._log_call.call_count == 50


### PR DESCRIPTION
## Summary
- Make FeedbackMemory singleton initialization thread-safe
- Protect FeedbackMemory add/search operations with RLock
- Save FeedbackMemory index and metadata through temp files and os.replace
- Make UnifiedRouter a process-level singleton while preserving direct UnifiedRouter() call sites
- Protect provider switch budget updates with an instance state lock
- Add concurrency tests for memory and router behavior

## Validation
- python scripts/scope_guard.py .
- python -m pytest tests/test_concurrency.py tests/test_router.py tests/test_brain_loop.py -q --tb=short
- python -m pytest tests/test_safety.py tests/test_hitl.py tests/test_promotion_state_machine.py -q --tb=short
- python -m pytest tests/ -q --tb=short

## Scope
- apps/llm_router/router.py
- domains/feedback_memory.py
- tests/test_concurrency.py
- No HITL/promotion flow changes
- No graph changes
- No Docker or requirements changes

## Notes
- UnifiedRouter is now a process singleton; first initialization parameters apply for the process lifetime.
- FeedbackMemory atomic save prevents partial single-file writes but does not implement a two-file transaction across index and metadata.