### PR TITLE
Document JOB runtime metadata fields

### DIFF
--- a/docs/JOB_SPEC.md
+++ b/docs/JOB_SPEC.md
@@ -65,3 +65,89 @@ priority: P1
 
 Jobs WITHOUT `domain` field continue to use `work/wiki/` and all squads —
 fully backward compatible with MVP 1.0.0.
+
+## Runtime Metadata Fields
+
+This section documents fields written to the JOB frontmatter by the system during execution. These fields enable self-observability and coordinate the HITL (Human-In-The-Loop) promotion lifecycle.
+
+### 1. Core State
+
+- `status`
+    - The persisted lifecycle state of the job.
+    - **Note**: Valid values and transitions are defined by [job_lifecycle_spec.md](../doc/job_lifecycle_spec.md). This document specifies field shape and usage, not the authoritative state machine.
+
+### 2. Audit & Artifact Fields
+
+- `audit_result`
+    - Type: `string` (values: `pass` | `fail`)
+    - Written by: `graph.py` (audit node) or standalone audit script.
+    - Used by: `promote.py` as a prerequisite for staging.
+- `audit_error`
+    - Optional diagnostic string containing details about why an audit failed.
+- `artifact_path`
+    - Workspace-relative path to the generated artifact (e.g., `work/blackboard/JOB-ID.md`).
+    - Used by: `slack_adapter.py` for notification and `promote.py` for staging.
+
+### 3. HITL Approval Fields
+
+The system tracks human approvals at three distinct gates.
+
+- **Gate 1: Initial Execution**
+    - `approved_by`: Name of the operator who authorized the initial graph run.
+    - `approved_at`: ISO 8601 timestamp of authorization.
+- **Gate 2: Promotion Staging**
+    - `approved_gate_2_by`: Name of the reviewer (via CLI or Slack).
+    - `approved_gate_2_at`: ISO 8601 timestamp.
+- **Gate 3: Wiki Promotion (Execution)**
+    - `approved_gate_3_by`: Name of the final authority (CLI only).
+    - `approved_gate_3_at`: ISO 8601 timestamp.
+    - **Requirement**: Gate 3 approval is strictly required before `promote.py --mode execute` will write to the canonical wiki.
+
+### 4. Gate 2 Rejection Metadata
+
+If a reviewer rejects a job at Gate 2, the following fields are recorded:
+
+- `rejected_gate`: Integer (always `2` for Gate 2).
+- `rejected_by`: Name of the person who rejected the request.
+- `rejected_at`: ISO 8601 timestamp.
+- `reject_reason`: Detailed feedback provided to the agents.
+- **Note**: Gate 3 rejection is currently unsupported in the MVP; Gate 3 is a final execute/no-execute decision.
+
+### 5. Slack Notification Metadata
+
+- `slack_ts`
+    - The unique timestamp (`ts`) of the Slack notification message.
+    - Used to prevent duplicate Gate 2 notifications and to update the message thread with status changes.
+    - **Note**: Slack is used for Gate 2 notifications, approvals, and rejections only; it cannot perform Gate 3.
+
+### 6. Staging / Promotion Metadata
+
+- `staged_artifact_path`
+    - Path to the staged artifact under `work/artifacts/staging/JOB-###/`.
+- `artifact_hash`
+    - SHA-256 hash of the artifact generated during `stage`.
+    - Used to verify integrity and prevent mid-approval tampering before `execute`.
+- `staged_at`
+    - Timestamp when `promote.py --mode stage` was successfully run.
+- `promoted_at`
+    - Timestamp of final wiki write.
+- `promoted_hash`
+    - Final integrity record of the promoted content.
+- `promoted_path`
+    - Final destination path in the canonical wiki (e.g., `domains/game/wiki/...`).
+    - **Note**: Canonical wiki writes occur only during the `execute` phase.
+
+### 7. Optional Trace Fields
+
+- `gate_1_rejected_by`
+    - An optional CLI trace field recorded if the initial authorization is rejected.
+    - This is a diagnostic trace and not part of the primary promotion path.
+
+### 8. Reserved / Lifecycle-spec Fields
+
+The following fields are referenced by architectural specifications but are not currently written consistently by the runtime implementation:
+
+- `failure_reason`: Diagnostic code for terminal failures (e.g., `provider_budget_exhausted`).
+- `failure_node`: The specific graph node where the unrecoverable error occurred.
+
+These fields are reserved for future schema synchronization and should not be treated as implemented runtime metadata.


### PR DESCRIPTION
## Summary
- Add Runtime Metadata Fields section to docs/JOB_SPEC.md
- Document implemented JOB frontmatter fields written during audit, HITL, Slack notification, staging, and promotion
- Clarify Gate 1 uses approved_by / approved_at while Gate 2 and Gate 3 use gate-specific approval fields
- Document Gate 2 rejection metadata and Slack notification metadata
- Document staging and promotion metadata including artifact_hash, staged_at, promoted_hash, and promoted_path
- Separate reserved lifecycle-spec fields from implemented runtime metadata

## Validation
- python scripts/scope_guard.py .
- python -m pytest tests/test_promotion_state_machine.py tests/test_hitl.py tests/test_hitl_gated_promotion.py -q --tb=short
- git grep checks for file:///, work/staged, approved_gate_3_by, artifact_hash, and slack_ts

## Scope
- docs/JOB_SPEC.md only
- No code changes
- No test changes
- PR-A2.3 release/docs sync deferred