### PR TITLE
Align Slack walkthrough with Gate 2 boundary

### DIFF
--- a/docs/walkthrough_slack.md
+++ b/docs/walkthrough_slack.md
@@ -1,5 +1,12 @@
 # Antigravity Slack HITL Walkthrough
 
+> **Boundary note:**
+> Slack is limited to Gate 2 notification, approval, and rejection.
+> Slack cannot perform Gate 3 and cannot write canonical wiki content.
+> LangGraph stops after audit and has no `promote` node.
+> Canonical wiki writes occur only through `scripts/promote.py --mode execute` after Gate 3 CLI approval.
+
+
 ## 1. Setup & Environment
 Slack 連携を有効にするには、以下の環境変数を `.env` に設定する必要があります。
 
@@ -18,7 +25,7 @@ SLACK_ADMIN_USER_IDS=U...,U... # カンマ区切り
 ```
 
 ## 3. HITL サイクル（実機検証済み）
-以下の手順で Slack 上での承認フローが完結することを確認しました。
+以下の手順で Slack 上での Gate 2 承認・却下フローが完結することを確認しました。
 
 ### 3.1 通知 (Audit Pending)
 - ジョブが `audit_passed` になると、Slack チャンネルに **[Approve] [Reject]** ボタン付きの Block Kit メッセージが投稿されます。
@@ -28,16 +35,18 @@ SLACK_ADMIN_USER_IDS=U...,U... # カンマ区切り
 - 管理者が **[Approve ✅]** をクリック。
 - **内部処理**: `slack_adapter.py` が `is_authorized` をチェック。
 - **結果**: 
-    - 物理 JOB ファイルのステータスが `approved_gate_3` に更新。
+    - 物理 JOB ファイルのステータスが `approved_gate_2` に更新。
     - Slack のメッセージが「✅ *Approved by @user*」に書き換わる。
-    - Daemon が次回のループでジョブを検知し、`Promote` ノードを起動。
+    - **Slack approval is Gate 2 only.** Gate 3 remains CLI-only via `scripts/approve.py --gate 3`.
+    - `wiki_daemon` が次回のループでジョブを検知し、`scripts/promote.py --mode stage` を実行します。
 
 ### 3.3 拒否操作 (Reject)
 - 管理者が **[Reject ❌]** をクリック。
 - **内部処理**: モーダルが表示され、理由を入力。
 - **結果**:
-    - 物理 JOB ファイルに拒否理由が追記され、ステータスが `gate_3_rejected` に更新。
+    - 物理 JOB ファイルに拒否理由が追記され、ステータスが `gate_2_rejected` に更新。
     - Slack メッセージが「❌ *Rejected by @user*」に書き換わる。
+    - メタデータ項目: `rejected_gate: 2`, `rejected_by`, `rejected_at`, `reject_reason`
 
 ## 4. セキュリティ・ガード
 - **ホワイトリスト**: `SLACK_ADMIN_USER_IDS` に含まれないユーザーがボタンを押した場合、本人にのみ見える（ephemeral）警告メッセージが表示され、処理は拒否されます。


### PR DESCRIPTION
## Summary
- Clarify Slack is limited to Gate 2 notification, approval, and rejection
- Replace stale approved_gate_3 / gate_3_rejected walkthrough states with approved_gate_2 / gate_2_rejected
- Remove stale Promote node wording
- Document that Gate 3 remains CLI-only and canonical wiki writes occur only through promote.py --mode execute

## Validation
- python scripts/scope_guard.py .
- python -m pytest tests/test_promotion_state_machine.py tests/test_hitl.py tests/test_hitl_gated_promotion.py -q --tb=short
- git grep checks for approved_gate_3, gate_3_rejected, Promote, promote node, and Gate 3 wording

## Scope
- docs/walkthrough_slack.md only
- No code changes
- No test changes